### PR TITLE
refactor: add enrollment start

### DIFF
--- a/policies/Demo_Course/policy.json
+++ b/policies/Demo_Course/policy.json
@@ -14,6 +14,7 @@
         "display_name": "Demonstration Course",
         "due": null,
         "end": null,
+        "enrollment_start": "2013-02-05T00:00:00Z",
         "format": null,
         "giturl": null,
         "graceperiod": "18000 seconds",


### PR DESCRIPTION
This is a [backport](https://github.com/openedx/openedx-demo-course/pull/38) from the master branch
Set the enrollment start date to the same value as the course start date.

This change is needed because in https://github.com/openedx/edx-platform/pull/30954 default enrollment start was added to fix the course listing for an anonymous user on the index page.

Using the demo course with an empty enrollment date for import you'll get the course with the default enrollment date equal to the default course start (1 Jan 2030 for now). This will cause the deployment error when trying to enroll audit and verified users in the demo course.